### PR TITLE
Feat: SellerContract 생성버튼, 리스트별 정산(settle)버튼 추가

### DIFF
--- a/src/components/ListItem.jsx
+++ b/src/components/ListItem.jsx
@@ -2,6 +2,7 @@ import { Box, Button } from '@mui/material';
 import axios from 'axios';
 import React from 'react';
 import { useNavigate } from 'react-router-dom';
+import * as contractApi from '../services/contract';
 
 export default function ListItem(props) {
   console.log(props.pageState);
@@ -9,6 +10,16 @@ export default function ListItem(props) {
   const navigate = useNavigate();
   const token = localStorage.getItem('token');
   const type = localStorage.getItem('type');
+
+  async function handleSettle() {
+    await contractApi.init();
+    const address = props.sellerAddr;
+    console.log(`SellerContract address: ${address}`);
+    contractApi.settlementContract.load(address);
+    const result = await contractApi.settlementContract.settle();
+    console.log(`settle() Transaction: ${result.transactionHash}`);
+  }
+
   return props.pageState === 'Board' ? (
     <Box
       sx={{ display: 'flex', textAlign: 'center', border: '0.5px solid', margin: '1.3%', borderRadius: '0.2em' }}
@@ -30,7 +41,7 @@ export default function ListItem(props) {
       <Box sx={{ width: '33%' }}>{props.album}</Box>
       <Box sx={{ width: '33%' }}>
         {type === 'Producer' ? (
-          <Button color="secondary" onClick={() => console.log('정산 컨트렉트는 여기!!')}>
+          <Button color="secondary" onClick={async () => handleSettle()}>
             settle
           </Button>
         ) : (

--- a/src/page/LibraryPage.jsx
+++ b/src/page/LibraryPage.jsx
@@ -74,6 +74,7 @@ function LibraryPage() {
                 album={item.album}
                 artist={item.artist}
                 user_id={item.user_id}
+                sellerAddr={item.sellerAddr}
                 pageState="Library"
               >
                 {console.log(item)}

--- a/src/page/UploadPage.jsx
+++ b/src/page/UploadPage.jsx
@@ -19,6 +19,7 @@ import {
 import { createTheme, ThemeProvider } from '@mui/material/styles';
 import styled from 'styled-components';
 import { useDropzone } from 'react-dropzone';
+import * as contractApi from '../services/contract';
 
 const thumbsContainer = {
   display: 'flex',
@@ -86,6 +87,8 @@ function RegisterPage() {
   const [checked, setChecked] = useState(false);
   const [registerError, setRegisterError] = useState('');
   const token = localStorage.getItem('token');
+  let userId = '1';
+  let sellerContractAddress;
 
   const onhandlePost = async (data) => {
     const { title, album, lylics, file, image } = data;
@@ -95,8 +98,7 @@ function RegisterPage() {
     await axios
       .post(`http://${process.env.REACT_APP_BACKEND_URL}/api/v1/upload`, {
         headers: {
-          authorization:
-            `${token}`
+          authorization: `${token}`,
         },
         data: postData,
       })
@@ -119,10 +121,19 @@ function RegisterPage() {
     setChecked(event.target.checked);
   };
 
+  const handleCreateSellerContract = async (userId) => {
+    await contractApi.init();
+    const sellerContract = await contractApi.deployContract.seller(userId);
+    sellerContractAddress = sellerContract.options.address;
+    console.log(sellerContract);
+    console.log(`sellerContractAddress: ${sellerContractAddress}`);
+  };
+
   const handleSubmit = (e) => {
     e.preventDefault();
 
     const data = new FormData(e.currentTarget);
+    console.log(data);
     const genreType = genre;
     const joinData = {
       title: data.get('title'),
@@ -136,7 +147,6 @@ function RegisterPage() {
 
     // 회원가입 동의 체크
     if (!checked) alert('올바른 양식과 함께 업로드 약관에 동의해주세요.');
-
     if (checked) {
       onhandlePost(joinData);
     }
@@ -332,6 +342,17 @@ function RegisterPage() {
                     />
                   </Grid>
                 </Grid>
+                <Button
+                  onClick={async () => {
+                    handleCreateSellerContract(userId);
+                  }}
+                  fullWidth
+                  variant="contained"
+                  sx={{ mt: 3, mb: 1 }}
+                  style={{ backgroundColor: '#7966ce', height: '60px', fontSize: '20px' }}
+                >
+                  SellerContract 생성
+                </Button>
                 <Button
                   type="submit"
                   fullWidth

--- a/src/services/metamask.js
+++ b/src/services/metamask.js
@@ -14,6 +14,8 @@ class Metamask {
     this.web3Provider = await detectEthereumProvider();
     if (!this.web3Provider) {
       console.log('Please install MetaMask!');
+      alert('Please install MetaMask!');
+      return;
     }
     await window.ethereum
       .request({
@@ -25,6 +27,7 @@ class Metamask {
           console.log('Please connect to MetaMask.');
         } else {
           console.error(error);
+          alert('Please connect to MetaMask.');
         }
       });
     this.web3 = new Web3(this.web3Provider);


### PR DESCRIPTION
### 주요 변경 사항
<!-- 변경사항에 대한 내용 -->
- 메타마스크 미설치시 alert 발생하도록 기능 추가
- 곡 업로드시 sellerContract 생성하는 버튼 추가
- 리스트별 곡 정산(settle) 버튼 추가 
---

### 코드 설명
<!-- 대략적인 코드설명 -->
- 메타마스크 미설치시 `console.log` 와 함께 `alert` 발생
- 곡 업로드 페이지에 있는 "sellerContract 생성" 버튼 클릭시 컨트렉트 생성 후 `console.log`로 transaction hash 출력 
- 리스트별로 들어오는 address의 contract를 `load()` 후 `settle()`하여 정산 수행  
---

### 중요도
<!-- checked : [X], unchecked : [ ] -->
- [ ] 낮음
- [ ] 보통
- [X] 높음
---

### 기타 특이사항
<!-- review시 중요하게 봐야할 내용 또는 특이사항 또는 궁금한점을 작성해주세요-->
<!-- 없으면 없음 기입 -->
 issue: #68 