### PR TITLE
Fix: 음원 업로드시 저작권자 중복 입력시 발생 오류 해결 및 구매시 backend post

### DIFF
--- a/src/page/SongInfoPage.jsx
+++ b/src/page/SongInfoPage.jsx
@@ -6,16 +6,6 @@ import { useLocation, useNavigate } from 'react-router-dom';
 
 import * as contractApi from '../services/contract';
 
-async function handleBuy(address) {
-  await contractApi.init();
-  contractApi.settlementContract.load(address);
-  const result = await contractApi.settlementContract.buy();
-  const txLog = await contractApi.settlementContract.event.getBuyLog(result);
-  console.log(`buy() Transaction: ${result.transactionHash}`);
-  window.alert(`구매가 완료되었습니다.\ntxid: ${result.transactionHash}`);
-  console.log(txLog);
-}
-
 export default function SongInfo() {
   const { state } = useLocation();
   const { id } = state;
@@ -25,6 +15,25 @@ export default function SongInfo() {
   const [address, setAddress] = useState('');
   const token = localStorage.getItem('jwtToken');
   // console.log(token);
+  async function handleBuy(address) {
+    await contractApi.init();
+    contractApi.settlementContract.load(address);
+    const result = await contractApi.settlementContract.buy();
+    const txLog = await contractApi.settlementContract.event.getBuyLog(result);
+    console.log(`buy() Transaction: ${result.transactionHash}`);
+    console.log(txLog);
+    await axios({
+      method: 'post',
+      headers: {
+        authorization: token,
+      },
+      url: `http://${process.env.REACT_APP_BACKEND_URL}/api/v1/purchase/${id}`,
+      data: { hash: result.transactionHash },
+    }).then((res) => {
+      console.log(res.message);
+      alert(`${res.message}\ntxid: ${result.transactionHash}`);
+    });
+  }
 
   const getRes = async () => {
     setLoading(true);

--- a/src/page/SongInfoPage.jsx
+++ b/src/page/SongInfoPage.jsx
@@ -31,7 +31,7 @@ export default function SongInfo() {
       data: { hash: result.transactionHash },
     }).then((res) => {
       console.log(res.message);
-      alert(`${res.message}\ntxid: ${result.transactionHash}`);
+      alert(`구매가 완료되었습니다!\ntxid: ${result.transactionHash}`);
     });
   }
 


### PR DESCRIPTION
### 주요 변경 사항
<!-- 변경사항에 대한 내용 -->
- 업로드 페이지 저작권자 입력란에 저작권자 중복입력 발생시 중복 주소를 합치고, 중복 주소의 각 비율들을 합침
- 음원 구매시 backend에 구매내역 post request하는 코드 추가
-  구매 완료시 성공 메세지에 Transaction Hash 표기
---

### 코드 설명
<!-- 대략적인 코드설명 -->
- 저작권자 중복 입력 해결 
  1. 저작권자를 key로 하고 비율을 value로 하는 object 생성 후 중복 비율은 누적합
  2. 이후 다시 key, value array로 나눠 cid2(PayProperty), 컨트렉트 생성에 사용
- 음원 구매시 `axios` 를 통한 `post` request 추가 
---

### 중요도
<!-- checked : [X], unchecked : [ ] -->
- [ ] 낮음
- [ ] 보통
- [x] 높음
---

### 기타 특이사항
- https://github.com/UXMUnderGraduate/22-S-Backend/issues/87#issuecomment-1328064245 해결